### PR TITLE
Use `autoPatchelfHook` on linux only

### DIFF
--- a/mk-solc-static.nix
+++ b/mk-solc-static.nix
@@ -33,7 +33,7 @@ let
     };
     dontUnpack = true;
 
-    nativeBuildInputs = [ autoPatchelfHook ];
+    nativeBuildInputs = lib.optionals (!stdenv.isDarwin) [ autoPatchelfHook ];
 
     installPhase = ''
       runHook preInstall


### PR DESCRIPTION
The flake fails to evaluate on M1 macs with the following:

```
nix shell github:hellwolf/solc.nix#solc_0_8_13         
error: Package ‘auto-patchelf-hook’ in /nix/store/v8ni21i7a4kh64axzfn8ry0pa507qrc2-source/pkgs/build-support/trivial-builders.nix:87 is not supported on ‘aarch64-darwin’, refusing to evaluate.

       a) To temporarily allow packages that are unsupported for this system, you can use an environment variable
          for a single invocation of the nix tools.

            $ export NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1

        Note: For `nix shell`, `nix build`, `nix develop` or any other Nix 2.4+
        (Flake) command, `--impure` must be passed in order to read this
        environment variable.

       b) For `nixos-rebuild` you can set
         { nixpkgs.config.allowUnsupportedSystem = true; }
       in configuration.nix to override this.

       c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
         { allowUnsupportedSystem = true; }
       to ~/.config/nixpkgs/config.nix.
(use '--show-trace' to show detailed location information)
```

related to: https://github.com/trezor/trezor-firmware/issues/2356