### PR TITLE
added support for macos-aarch binaries

### DIFF
--- a/solc-listing.nix
+++ b/solc-listing.nix
@@ -4,6 +4,7 @@
   sha256 = {
     solc-static-linux = "sha256-+wOimlF0UrnxK89FnvN9ClQ3Zbs7vJEecKh9ajfDDV8=";
     solc-macos = "sha256-zC1ExwaQXMw4L0hGJd/2HXQeDCQjLSJvE5poNfxkTz8=";
+    solc-macos-aarch = "sha256-HLG/xM32hz6/NtxlMXqKBhQJa5wrzKW7H3DVfTGcUKY=";
   };
 }
 {
@@ -11,6 +12,7 @@
   sha256 = {
     solc-static-linux = "sha256-KHJqRSKQxw4ZhPFcU60wiOfZh4PuMHCxGzZk2ndBVzI=";
     solc-macos = "sha256-4JpCmA5EZEvjOoRVyH0JWk8AKOQafd4RN/XZp2BaLWI=";
+    solc-macos-aarch = "sha256-35D9WAySlw5kQfpLabWONk4z8e8Nprja5JryielyoHU=";
   };
 }
 {
@@ -18,6 +20,7 @@
   sha256 = {
     solc-static-linux = "sha256-i+Cut0/BuCEykqCahMtSSkA2AlJt+H7K1fXNKn6n0Ik=";
     solc-macos = "sha256-yNO3gDwOssO900ssO5cG6djIG4gpJQ5JJF2suYSmLgU=";
+    solc-macos-aarch = "sha256-KhkJcPk/P482Md9uq9JFmU/8VVjo772U1Zem9Ef1mzM=";
   };
 }
 {
@@ -25,6 +28,7 @@
   sha256 = {
     solc-static-linux = "sha256-8oV6iYvhXGno3lWY3NPz4WnpSWSgzpoLuxsRHxRagd8=";
     solc-macos = "sha256-GdBldJ+wjL/097RShKxVhTBjhl9q6GIeTe+l2Ti5pQI=";
+    solc-macos-aarch = "sha256-U6DH2V0S8FvkKi5fb86VCdYjFGS9ASBRiku0rjMteRI=";
   };
 }
 {
@@ -32,6 +36,7 @@
   sha256 = {
     solc-static-linux = "sha256-BHnUT9+cUBwlM3/cVAQZ8Vk7iEqHtH8CPaTxxwD9p4I=";
     solc-macos = "sha256-/DKZReAGjk6VXQp7WDd23I0l5yq2V6BEYYp8590FGao=";
+    solc-macos-aarch = "sha256-XZjJ7YkrdOytxKt/k95iEf3eA1HvZvLLkOsRYw4w4qs=";
   };
 }
 {
@@ -39,6 +44,7 @@
   sha256 = {
     solc-static-linux = "sha256-elwdPcmo66Yrsuw3GSyReK5f6KVKVuVXP9PJwXzZ60g=";
     solc-macos = "sha256-OMhSOrZ+Cz4hxIGJ1r+5mtaHm5zgLg2ALsi+WYuyYi0=";
+    solc-macos-aarch = "sha256-SeGuVTTNDl1Hp8D7j+vmRbsCwcLVCSYzQq+7BCoN964=";
   };
 }
 {
@@ -46,6 +52,7 @@
   sha256 = {
     solc-static-linux = "sha256-lebtSUmmOtia+0Q+y6H7gwLdKGDuXpuqzj5nSg9Iqnc=";
     solc-macos = "sha256-jxUofHma0rM/JB0SUiJqvaXUvD72vkC5RpIxePxX05c=";
+    solc-macos-aarch = "sha256-V4Sxf7qM5AMPLImhMLMItstdJDaWq0jbLdYPSbAAVpg=";
   };
 }
 {
@@ -53,6 +60,7 @@
   sha256 = {
     solc-static-linux = "sha256-mfIHC3dulxTx92xDwinPmbiXipKTjujSNkxt4RwaA9Q=";
     solc-macos = "sha256-5A7vg8JNTEK0f0YbAXSKbKifHgnneJlbcd6/oN6Z4So=";
+    solc-macos-aarch = "sha256-9aOOn4cO8uAOcUYwITuyXlDggPa3cqclNzjmR2IbpOY=";
   };
 }
 {
@@ -60,6 +68,7 @@
   sha256 = {
     solc-static-linux = "sha256-FjJ4bGwfhWpKiZIy7JdaEvMFEY9DzOkOck7Qsu6/7uE=";
     solc-macos = "sha256-fUccubrpp/Kcfr9AL34W+oImsXupq2iojOEHEUR53E0=";
+    solc-macos-aarch = "sha256-sb5g1lBG+fi8WLks/R9EClQWfp/uNAtWjGFg6oVU0RE=";
   };
 }
 {
@@ -67,6 +76,7 @@
   sha256 = {
     solc-static-linux = "sha256-UYkVXOMi1X+3XoUY2bOROWJ+3qT7JbXw6+0DkcUudMw=";
     solc-macos = "sha256-AGVtxzIk5MBwKUDfEDEL3AJLYPSnWY53TTBbw7lPfXk=";
+    solc-macos-aarch = "sha256-C2YZ7hSvVqt6b1mT9C0tcAqh3ab5+yx09d9S7rY2kwc=";
   };
 }
 {
@@ -74,6 +84,7 @@
   sha256 = {
     solc-static-linux = "sha256-1bAnyGwPj+zAJNXU+V2OpI2KlC15lwMQ40I3BTK1AvA=";
     solc-macos = "sha256-s9GatHZXrze+TFUfg0lCSOmde6EDtgcujAjbticI4rA=";
+    solc-macos-aarch = "sha256-t2+hD60EXRNz3VfFGaRycZLcBLzv/oY/vbAVY4/kZ74=";
   };
 }
 {
@@ -81,6 +92,7 @@
   sha256 = {
     solc-static-linux = "sha256-qAXf+obM2O1cnNGP/PzKb/RvY1IWqn/AJGVG975BPWI=";
     solc-macos = "sha256-FNTvAT6oKtlekf2Um3+nt4JxpIP/GnnEPWzFi4JvW+o=";
+    solc-macos-aarch = "sha256-QoN79Wjo63d8azdsTuUlKT90BfgrnGVqEJPUKzrCpaY=";
   };
 }
 {
@@ -88,6 +100,7 @@
   sha256 = {
     solc-static-linux = "sha256-VWw+xE+vj/a2eTP6iopAOr6CyXjW5YHb/sS9BzYL+/M=";
     solc-macos = "sha256-lXOKJ5CaE1Ajhen+j489ioc9L69dBv9he8L+PtuMS/k=";
+    solc-macos-aarch = "sha256-ez+u2xfBcJZBh30afn1U6vcTkp+tvIvlzJ2eJKuLnMc=";
   };
 }
 {
@@ -95,6 +108,7 @@
   sha256 = {
     solc-static-linux = "sha256-cXwjnzodw6SDTBYEagtLn0aWRmXI/6ggUabQn+dBzU8=";
     solc-macos = "sha256-EM3MjY6k3en9i5U7lYhdxzfyS4ox/qZfRxX/0Ae4AoE=";
+    solc-macos-aarch = "sha256-X9A8t6nTlZ6jOLjETxTugRUfswsqdjt6/DDFWtB/T+U=";
   };
 }
 {
@@ -102,6 +116,7 @@
   sha256 = {
     solc-static-linux = "sha256-x+/6zyi51kSV+Bt1Io+/QmasDsh+jxrcSJ3dik3QbYk=";
     solc-macos = "sha256-p5//I66zW+hW5EaCfESpz6TDgvKbq9L2pAXvc9HipMw=";
+    solc-macos-aarch = "sha256-k+qHA0/grzsqhMy58sB14hoFu0XXDKjHLSGqvtrmXQ4=";
   };
 }
 {
@@ -109,6 +124,7 @@
   sha256 = {
     solc-static-linux = "sha256-+FHxH603SWuquvjWy1wFfKDZdU/dt6NRq1gNf9coy5Q=";
     solc-macos = "sha256-1hnU9dj9mIvGMmJAfnSekFzMjYqxzPAoDaHRK5GIlM4=";
+    solc-macos-aarch = "sha256-WZb+gMihrCj2AQzqPMuxwrvQ4lOR5Sxig5tvoF0efqw=";
   };
 }
 {
@@ -116,6 +132,7 @@
   sha256 = {
     solc-static-linux = "sha256-5nexIWsTbGHjiTSj3jqOZ94/cz16so8PBGvUoHiwy7A=";
     solc-macos = "sha256-FCLhBFQlHVb+9ilA+y4gmm9GeuNfc73OWAvAutNYUd0=";
+    solc-macos-aarch = "sha256-V3DA9CFkb66WTFWCPfE7QmVQAQAZFlkcrUcgdQJUtlc=";
   };
 }
 {
@@ -123,6 +140,7 @@
   sha256 = {
     solc-static-linux = "sha256-AD11OD5FIS+YEtC2rdkDKf07I55sN40ogvYfk0WJbZk=";
     solc-macos = "sha256-zFxmPR/hfU60rKCSU3h6yGuHhSNfynHZIAVp5mJneZA=";
+    solc-macos-aarch = "sha256-DKHiTDR1baPe/JKeyQbbPlDW9R6CzDxgeMjdAK0uyjo=";
   };
 }
 {
@@ -130,6 +148,7 @@
   sha256 = {
     solc-static-linux = "sha256-q9XE8/JivD7XlRuWjGP5joP2bZpcNWirMG6sSSUK7D4=";
     solc-macos = "sha256-hu6Z9k/H42v6BGFptqTUwQ6zUBftEeDJcPASI7L12zY=";
+    solc-macos-aarch = "sha256-UA1Kx+/vgEd+xy872P01pspO6hy9nklZ0nDGD0iJolo=";
   };
 }
 {
@@ -137,6 +156,7 @@
   sha256 = {
     solc-static-linux = "sha256-vXggB6fVBQDSJwMUWs5tRMkWyFPNDQ/LLK6rn6X6M+c=";
     solc-macos = "sha256-NCHuZ6Ju9Kcg55Ux/9m5be7Ine+81wu0oz6WixLduTg=";
+    solc-macos-aarch = "sha256-+qzRm8nEC1fbLfAH+6IHtEdEHzKz0V8HiS1H4LmJrbE=";
   };
 }
 {
@@ -144,6 +164,7 @@
   sha256 = {
     solc-static-linux = "sha256-9xFcyvEYmdzzqqiIlJ+GFEIfLRCvZadIcLz9ZwENp/g=";
     solc-macos = "sha256-T28uaUKgkFG7vIUNT6mw2Qd0lhLLXbWMrAyHdFQ1Bw8=";
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -151,6 +172,7 @@
   sha256 = {
     solc-static-linux = "sha256-+zOv12HQ1wRnHa1YLTtKeQ1NhaY3D+cbP4k1ZJaB4pI=";
     solc-macos = "sha256-EYj1wk0z7B7CzoEaekW9w8Fn8bpxy8JmQBZWTS/dRro=";
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -158,6 +180,7 @@
   sha256 = {
     solc-static-linux = "sha256-trlCnXHUOVkBeVk2oKruCyMIL8ruENVj2HtC5pwOaMI=";
     solc-macos = "sha256-CJjCOwrIzavO47ZGtnbaEgX0vnwL7IpY3oGwYMWbTBw=";
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -165,6 +188,7 @@
   sha256 = {
     solc-static-linux = "sha256-2qf21swKMWvrJgdTMYO2SQR5hnewy5m9oFSepw6N5ho=";
     solc-macos = "sha256-OFBONXYywVr+1hLCDvh4mSyoQRzj+2r+433sbr0izgI=";
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -172,6 +196,7 @@
   sha256 = {
     solc-static-linux = "sha256-ZAFjEKV8rxr3ajYQ8flMiEjATJZz5/omhJLmCJGKS9w=";
     solc-macos = "sha256-x8P/SE0t1pNQ/BgtROz2BX/yiFuWocOZDKNi6cgyUzU=";
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -179,6 +204,7 @@
   sha256 = {
     solc-static-linux = "sha256-vWnqhUJ78vTadMtCatlR3Xjbnf3QHXkSCOzMLUlYprs=";
     solc-macos = "sha256-pqj5+TiMX82SIkdOACcCQsgy6Taw9SV8IDdNJ+5b0as=";
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -186,6 +212,7 @@
   sha256 = {
     solc-static-linux = "sha256-lvsiE0wQk5M0xiyMCmaLcSaW+PgUJub88ELw5wnnqh4=";
     solc-macos = "sha256-HBAM6GoxZ/1MGUKQqv7A09lP6Gx6GqCDfBNGzJPYts4=";
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -193,6 +220,7 @@
   sha256 = {
     solc-static-linux = "sha256-4Ppqg0elK8bsNR4iU35kW+ButQQYlEYLGpEU83MunQc=";
     solc-macos = "sha256-zOACaIzxD7AkOgQlA/PpiWqpkatZsItXlx1C1o6Z+D0=";
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -200,6 +228,7 @@
   sha256 = {
     solc-static-linux = "sha256-Khfeo7F4XqxF5q8M4yivaOuUOmRjs24D0x2Z12UaKLE=";
     solc-macos = "sha256-8YUQTtXiqQs86N/HKDxdD/u3ONfI2hnoY13Z/aNMM3o=";
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -207,6 +236,7 @@
   sha256 = {
     solc-static-linux = "sha256-dZkws5bNoNF2Id1uyoqhajVwFFlgJUQx5sQugWJuWhA=";
     solc-macos = "sha256-VRhkH2xKKGBU9cnykUaXDvcvLzTudu0j9esfbR3P7Ns=";
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -214,6 +244,7 @@
   sha256 = {
     solc-static-linux = "sha256-wMSUAurxg1Pmv7j9xyYn7KXS1j+zal6nhxFN7pSXmao=";
     solc-macos = "sha256-VbgHLMasFUvyfyIXev5YvgXyjBHvUfxOZgMT0wRaQmg=";
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -221,27 +252,7 @@
   sha256 = {
     solc-static-linux = "sha256-EXRUeRkD00WHt7B2JsAyU8bURytvCfcu4AfPHyILSek=";
     solc-macos = "sha256-QFVdboJhBMrNDAtjfF+1c9W24qascBENwDM0ZsARXh0=";
-  };
-}
-{
-  version = "0.6.12";
-  sha256 = {
-    solc-static-linux = "sha256-9stRmwHavGHKtMGEo9sRqlkdGBUeNi/K6FDkLP/fsJo=";
-    solc-macos = "sha256-Ba2K+oPfO1HTb+moTqRGez7RdYXJA5RphdbizV6VaFo=";
-  };
-}
-{
-  version = "0.6.11";
-  sha256 = {
-    solc-static-linux = "sha256-LgkdXxO+oLxEXH9nTVz4yeQqPU414eUPAPTdRImFBao=";
-    solc-macos = "sha256-oKZKoJKmFq5xRdqQj8Qn/DwpbTr9v6jqNGiiJyLV0Bw=";
-  };
-}
-{
-  version = "0.6.10";
-  sha256 = {
-    solc-static-linux = "sha256-aMQUungyVXCjSBeoKbHzxioYmFcIolCXKbUPeYKaN0s=";
-    solc-macos = "sha256-N3PmbD7xTi5HvdfQbzD5UsGZhW3yQNFkyRwfAIBvu8c=";
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -249,6 +260,7 @@
   sha256 = {
     solc-static-linux = "sha256-60K+9XhKDewPG1TCYLN23rBJWUC/1HTES1vjHAtjRgM=";
     solc-macos = "sha256-mPvhB1VjitXMwGg4ELlhqANFDpS2Qq8RJZMkimhapNw=";
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -256,6 +268,7 @@
   sha256 = {
     solc-static-linux = "sha256-n3YWfHhjXNBIyjDnXZ2t5X6m8NA7gzhNZA1do46MWA0=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -263,6 +276,7 @@
   sha256 = {
     solc-static-linux = "sha256-ICY6oXwufKjBDs09QkLfYdudVJvB3bcrmjh8DBE2wc8=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -270,6 +284,7 @@
   sha256 = {
     solc-static-linux = "sha256-XYzU4MwC6ZRkl9towG1WMmp4/5WiHJJlz+24GaEKU50=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -277,6 +292,7 @@
   sha256 = {
     solc-static-linux = "sha256-Mydq3/jw5iCt9xxKtm10jQaQw0Ngzk9V4NGMd/oTR20=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -284,6 +300,7 @@
   sha256 = {
     solc-static-linux = "sha256-lt3YHqfZTW5/ETX3sRqx0GNa1Vhe2UFH8f45satyZvs=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -291,6 +308,7 @@
   sha256 = {
     solc-static-linux = "sha256-YB+HTipSx1ndzBB0y3XBKEjizomah0akPir/vSimVeE=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -298,6 +316,7 @@
   sha256 = {
     solc-static-linux = "sha256-EJyoxrkvRUjnjHKmTEfGFGF9eyteS2+Lnn1lT8UYY2U=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -305,6 +324,7 @@
   sha256 = {
     solc-static-linux = "sha256-SZwqrRMv/felnOh9iOT+zizNY/Wrfig7G+THIrBiBss=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -312,6 +332,7 @@
   sha256 = {
     solc-static-linux = "sha256-XEsw2hiw+l8a4xgxJ6Tc1konn8wV4WpHewhB1XZ3AoM=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -319,6 +340,7 @@
   sha256 = {
     solc-static-linux = "sha256-w1znpNP/pXR8F4seJMhUGy5dioLB2zcZ60QzofGeFvM=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -326,6 +348,7 @@
   sha256 = {
     solc-static-linux = "sha256-oV8BcA7H4C+Ru9/Utv9EULPC3srhc+T0GRCjz7r109M=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -333,6 +356,7 @@
   sha256 = {
     solc-static-linux = "sha256-vIFvIQTQ4xYXm85pr88kpItcbHIDy3K+ytfZ57ZpkLQ=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -340,6 +364,7 @@
   sha256 = {
     solc-static-linux = "sha256-SEVOKQ7/0bmyqoYAE97/CaebTXRyh1oH8+fVR98pfsw=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -347,6 +372,7 @@
   sha256 = {
     solc-static-linux = "sha256-W2IQXonCKfWVHQXysZr4EWNZnH8N7MBK+B4lOZY2aq8=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -354,6 +380,7 @@
   sha256 = {
     solc-static-linux = "sha256-cLbwo1U4XFrqJsdhsuWLMhaqVk9B5OFWgTvjxHpmrpw=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -361,6 +388,7 @@
   sha256 = {
     solc-static-linux = "sha256-NQ1avFhi3KQykkJrbU5ZL4H0CwLNqDPzhAa6AEe2udA=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -368,6 +396,7 @@
   sha256 = {
     solc-static-linux = "sha256-PJsujrmNQpT8RTJtr8vMtGpwmTw0bH07VaoCkrPKAzQ=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -375,6 +404,7 @@
   sha256 = {
     solc-static-linux = "sha256-OQ0UrEe0oB5PgEpXFZ/6UmwjKaDrCLniDe4AZJ77NGE=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -382,6 +412,7 @@
   sha256 = {
     solc-static-linux = "sha256-WPvpu7cJJ3lX/RK5IlMPA89VjPgDtyMzotdtVHV4hdE=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -389,6 +420,7 @@
   sha256 = {
     solc-static-linux = "sha256-gQxSz/KVEflcRPmhrisRwEWY1BPW/6N72xlBWSb7Wzc=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -396,6 +428,7 @@
   sha256 = {
     solc-static-linux = "sha256-88cKTXFre06BHvUgSzrmoWSXrnAaK4YmDRve5+RIS1M=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -403,6 +436,7 @@
   sha256 = {
     solc-static-linux = "sha256-cYx8xYGKkXnTYMpUIsnxOjEqK6+IhPPdi74yh+yu8MY=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -410,6 +444,7 @@
   sha256 = {
     solc-static-linux = "sha256-D940fbXmMvw67zyo2nSJbY33o1KHZG5/ve6Cn+I2BUo=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -417,6 +452,7 @@
   sha256 = {
     solc-static-linux = "sha256-vgjrlcs6HaUukYz1GgwDl/vn8GkxResxg1vykkIJ8eA=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -424,6 +460,7 @@
   sha256 = {
     solc-static-linux = "sha256-hxRqeyhLHJBnqRWTDAxq98mf+d0YB+NoA2f8A6Weg78=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -431,6 +468,7 @@
   sha256 = {
     solc-static-linux = "sha256-YnXUgfIxgOALOJloSFNNt4tPc8qsoVQ1rYYd9UW7cdA=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -438,6 +476,7 @@
   sha256 = {
     solc-static-linux = "sha256-wbsVtSD1B2rr16qe9M5fokW28hCpHL0gZLnjg+ZRDgg=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -445,6 +484,7 @@
   sha256 = {
     solc-static-linux = "sha256-n52loS/KJ411Fl9Mp17p0pDZ8L2Mq9WfFr85zwrGIZI=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -452,6 +492,7 @@
   sha256 = {
     solc-static-linux = "sha256-ybJodQUGuI/nE3EQAFDp3R5+3Pj2naNNHNCVV+yyRYA=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -459,6 +500,7 @@
   sha256 = {
     solc-static-linux = "sha256-ZlZ1ueBDHCVy1Z1qcRKvvcdScy6gzprs8aGFXyjgKgk=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -466,6 +508,7 @@
   sha256 = {
     solc-static-linux = "sha256-xkjSmb0h9MdM4XlUcGz8Wnqfu9Hoc5VG7YdUys2Mp8I=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -473,6 +516,7 @@
   sha256 = {
     solc-static-linux = "sha256-+t6bpt1In/w/c+U6E9XxAxMld5cI5EgiSXCXm4zIa6c=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -480,6 +524,7 @@
   sha256 = {
     solc-static-linux = "sha256-kFIoUFQgzTHmOT4J6mhbh1hbYsQznTrdwKMEm+u8QzI=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -487,6 +532,7 @@
   sha256 = {
     solc-static-linux = "sha256-2Wa4IVpPgzd86dYiyRmP6R5bkzAGUr8IGq8vaqOsahY=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -494,6 +540,7 @@
   sha256 = {
     solc-static-linux = "sha256-B/iXU83aKAVLtvFZohkRcWyutDs8dlmiXx8tndF7yCc=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -501,6 +548,7 @@
   sha256 = {
     solc-static-linux = "sha256-iYpeBdOsCNcmsBnSQVwcCHqa6HhmzfpVHAiza2tFMh0=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -508,6 +556,7 @@
   sha256 = {
     solc-static-linux = "sha256-E0FL+G+AMZ5vWGO0ykr3hpVtGI9fm5ndpkOTYsbZERU=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -515,6 +564,7 @@
   sha256 = {
     solc-static-linux = "sha256-eODabK0kqxRajRdCDE8JTIMUQYyiPP9LBQuyv9NvOvI=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -522,6 +572,7 @@
   sha256 = {
     solc-static-linux = "sha256-xxrGwovzsaQl536X9d9nqA2j5MBHJhh1IGVhwKEQwMs=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -529,6 +580,7 @@
   sha256 = {
     solc-static-linux = "sha256-KM41oJQdns1ZorGjd8AZEQ55prOL2/Wjv/6oEfnCoTs=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -536,6 +588,7 @@
   sha256 = {
     solc-static-linux = "sha256-eR7jogrfbFq3bMiJ8TzKEC926wt88NpKC1sR3Ebt80k=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -543,6 +596,7 @@
   sha256 = {
     solc-static-linux = "sha256-IhrjPhK9pci3lsmrrisutz5G2bEhKL/uRRsShW+LR+4=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 {
@@ -550,6 +604,7 @@
   sha256 = {
     solc-static-linux = "sha256-Co0TjuJFA55vgxLtwCS6PEc5zDwBO0fcf8kZai4yf+o=";
     # solc-macos not available for this version
+    # solc-macos-aarch not available for this version
   };
 }
 ]

--- a/utils/create-listing.sh
+++ b/utils/create-listing.sh
@@ -26,6 +26,7 @@ print_hash() {
   sha256 = {
     $(print_hash solc-static-linux "$c"/static-linux/"$s")
     $(print_hash solc-macos        "$c"/macos/"$s")
+    $(print_hash solc-macos-aarch  "$c"/macos-aarch/"$s")
   };
 }
 EOF

--- a/utils/download.sh
+++ b/utils/download.sh
@@ -13,13 +13,22 @@ list_all_versions() {
 
 download_one_version() {
     v=$1
+    # first download official binaries
     for j in static-linux macos; do
+        mkdir -p "$T/bin/$j"
         u=https://github.com/ethereum/solidity/releases/download/v$v/solc-$j
         o=$T/bin/$j/solc-$v
         # use -Nc for timestamping check and avoid redownloading
         # not all versions contain a macos binary, rm failed download
         wget -Nc "$u" -O "$o" || rm -f "$o";
     done
+    # second try download alloy macos binaries
+    mkdir -p "$T/bin/macos-aarch"
+    u=https://github.com/alloy-rs/solc-builds/raw/e4b80d33bc4d015b2fc3583e217fbf248b2014e1/macosx/aarch64/solc-v$v
+    o=$T/bin/macos-aarch/solc-$v
+    # use -Nc for timestamping check and avoid redownloading
+    # not all versions contain a macos binary, rm failed download
+    wget -Nc "$u" -O "$o" || rm -f "$o";
 }
 
 download_all_versions() {


### PR DESCRIPTION
Versions prior to v0.8.24 would not work on macos with M1/2/3 cpu unless Rosetta was used. This change allows the use of native binaries up until v0.8.5.

The helper scripts were updated accordingly and the listing extended.