### PR TITLE
file+https flake URI fails

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     flake-utils.url = "github:numtide/flake-utils";
     solc-macos-amd64-list-json = {
       # Go to https://github.com/ethereum/solc-bin/blob/gh-pages/macosx-amd64/list.json to obtain a revision
-      url = "file+https://github.com/ethereum/solc-bin/raw/f743ca7/macosx-amd64/list.json";
+      url = "https://github.com/ethereum/solc-bin/raw/f743ca7/macosx-amd64/list.json";
       flake = false;
     };
   };


### PR DESCRIPTION
We are seeing the following error when trying to update to the latest version of this flake:

```
error: file:// URL 'file+https://github.com/ethereum/solc-bin/raw/f743ca7/macosx-amd64/list.json' has unexpected authority 'github.com'
```

Is there a reason to not use the original `https` only, without `file+`?