### PR TITLE
Support official macosx universal builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Test Default Shell
         run: |
           set -x
-          nix develop .# --command -- bash -c "solc-0.8.24 --version"
+          nix develop .# --command -- bash -c "solc-0.8.26 --version"
           # overriding flake input is needed as a workaround to local sub flake with overlapping paths.
           nix develop ./test/.# --override-input solc $PWD --command -- bash -c "solc --version"
-          nix develop ./test/.# --override-input solc $PWD --command -- bash -c "solc-0.8.24 --version"
+          nix develop ./test/.# --override-input solc $PWD --command -- bash -c "solc-0.8.26 --version"
   ci-check-success:
     needs: [ci]
     runs-on: ubuntu-latest

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
         in
         {
           # default shell with the latest solc compiler
-          devShells.default = pkgs.mkShell { buildInputs = [ pkgs.solc_0_8_24 ]; };
+          devShells.default = pkgs.mkShell { buildInputs = [ pkgs.solc_0_8_26 ]; };
         }
       )
     // {

--- a/mk-solc-static-pkg.nix
+++ b/mk-solc-static-pkg.nix
@@ -33,13 +33,20 @@ let
   # The official solc binaries for macOS started supporting Apple Silicon with
   # v0.8.24. For earlier versions, the binaries from svm can be used.
   # See https://github.com/alloy-rs/solc-builds
+  macosUniversalBuildUrl = "https://binaries.soliditylang.org/macosx-amd64/${
+    solc-macos-amd64-list.releases.${version}
+  }";
+
   url =
     if solc-flavor == "solc-static-linux" then
       "https://github.com/ethereum/solidity/releases/download/v${version}/solc-static-linux"
     else if solc-flavor == "solc-macos-amd64" then
-      "https://binaries.soliditylang.org/macosx-amd64/${solc-macos-amd64-list.releases.${version}}"
+      macosUniversalBuildUrl
     else if solc-flavor == "solc-macos-aarch64" && builtins.compareVersions solc_ver "0.8.5" > -1 then
-      "https://github.com/alloy-rs/solc-builds/raw/master/macosx/aarch64/solc-v${version}"
+      if builtins.compareVersions solc_ver "0.8.24" == -1 then
+        "https://github.com/alloy-rs/solc-builds/raw/master/macosx/aarch64/solc-v${version}"
+      else
+        macosUniversalBuildUrl
     else
       throw "Unsupported version ${version} for ${system}";
 in

--- a/solc-listing.nix
+++ b/solc-listing.nix
@@ -4,7 +4,7 @@
   sha256 = {
     solc-static-linux = "sha256-1fI0NvRD7bhdjnaQbRLwqGzgSQ52Y6nmCO/repPxSe8=";
     solc-macos-amd64 = "sha256-D/AWrvI5axLR/GVCnY6mz1PC7ksEG7iSVkRhXuHDCrk=";
-    # solc-macos-aarch64 not available for this version
+    solc-macos-aarch64 = "sha256-D/AWrvI5axLR/GVCnY6mz1PC7ksEG7iSVkRhXuHDCrk=";
   };
 }
 {
@@ -12,7 +12,7 @@
   sha256 = {
     solc-static-linux = "sha256-xCqtp6UgV92+2T7AESNeJWxWTEQLaNuqxa5IK6u7PW0=";
     solc-macos-amd64 = "sha256-zD+UpwrGgbAwQISswZgKq+KhuzJA1Eznao3w4ed6IRA=";
-    # solc-macos-aarch64 not available for this version
+    solc-macos-aarch64 = "sha256-zD+UpwrGgbAwQISswZgKq+KhuzJA1Eznao3w4ed6IRA=";
   };
 }
 {

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -42,11 +42,18 @@
                 ++ (
                   if system == "x86_64-linux" then
                     [
-                      solc_0_4_26
+                      solc_0_4_11
                       solc_0_7_6
                     ]
+                  else if system == "x86_64-darwin" then
+                    [
+                      solc_0_4_11
+                      solc_0_7_6
+                    ]
+                  else if system == "aarch64-darwin" then
+                    [ solc_0_8_5 ]
                   else
-                    [ solc_0_7_6 ]
+                    throw "unknown system"
                 );
             };
         }

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -35,7 +35,10 @@
             with pkgs;
             mkShell {
               buildInputs =
-                [ solc_0_8_26 ]
+                [
+                  solc_0_8_26
+                  (solc.mkDefault pkgs solc_0_8_26)
+                ]
                 ++ (
                   if system == "x86_64-linux" then
                     [

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -35,21 +35,15 @@
             with pkgs;
             mkShell {
               buildInputs =
-                [ solc_0_8_24 ]
+                [ solc_0_8_26 ]
                 ++ (
                   if system == "x86_64-linux" then
                     [
                       solc_0_4_26
                       solc_0_7_6
-                      (solc.mkDefault pkgs solc_0_8_26)
-                    ]
-                  else if system == "x86_64-darwin" then
-                    [
-                      solc_0_7_6
-                      (solc.mkDefault pkgs solc_0_8_26)
                     ]
                   else
-                    [ (solc.mkDefault pkgs solc_0_8_24) ]
+                    [ solc_0_7_6 ]
                 );
             };
         }

--- a/utils/download.sh
+++ b/utils/download.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p semver-tool
 
 macos_versions=$(mktemp)
 curl https://binaries.soliditylang.org/macosx-amd64/list.json >"$macos_versions"
@@ -37,9 +38,17 @@ download_one_version() {
         "$T"/bin/macos-amd64/solc-"$v"
 
     mkdir -p "$T/bin/macos-aarch64"
-    run_wget \
-        https://github.com/alloy-rs/solc-builds/raw/master/macosx/aarch64/solc-v"$v" \
-        "$T"/bin/macos-aarch64/solc-"$v"
+    if [ "$(semver compare $v 0.8.23)" == 1 ]; then
+        # starting from 0.8.24, official solidity distribution started to provide universal builds
+        # references:
+        # - https://github.com/ethereum/solidity/issues/14813
+        # - https://github.com/alloy-rs/solc-builds/issues/13
+        ln -s ../macos-amd64/solc-"$v" "$T"/bin/macos-aarch64/solc-"$v"
+    else
+        run_wget \
+            https://github.com/alloy-rs/solc-builds/raw/master/macosx/aarch64/solc-v"$v" \
+            "$T"/bin/macos-aarch64/solc-"$v"
+    fi
 }
 
 download_all_versions() {


### PR DESCRIPTION
Starting from 0.8.24, official solidity distribution started to provide universal builds references:

- https://github.com/ethereum/solidity/issues/14813
- https://github.com/alloy-rs/solc-builds/issues/13
