### PR TITLE
Update references to solc-bin and solidity repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ A Solidity Compilers Collection in Nix
 ======================================
 
 This Nix flake provides a collection of static-linux and macos builds of [solidity compilers
-(solc)](https://github.com/ethereum/solidity/) as [an overlay](https://nixos.wiki/wiki/Overlays).
+(solc)](https://github.com/argotorg/solidity/) as [an overlay](https://nixos.wiki/wiki/Overlays).
 
 # Usage
 

--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
       "locked": {
         "narHash": "sha256-AvITkfpNYgCypXuLJyqco0li+unVw39BAfdOZvd/SPE=",
         "type": "file",
-        "url": "https://github.com/ethereum/solc-bin/raw/26fc3fd/macosx-amd64/list.json"
+        "url": "https://github.com/argotorg/solc-bin/raw/26fc3fd/macosx-amd64/list.json"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/ethereum/solc-bin/raw/26fc3fd/macosx-amd64/list.json"
+        "url": "https://github.com/argotorg/solc-bin/raw/26fc3fd/macosx-amd64/list.json"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,8 +5,8 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     solc-macos-amd64-list-json = {
-      # Go to https://github.com/ethereum/solc-bin/blob/gh-pages/macosx-amd64/list.json to obtain a revision
-      url = "file+https://github.com/ethereum/solc-bin/raw/26fc3fd/macosx-amd64/list.json";
+      # Go to https://github.com/argotorg/solc-bin/blob/gh-pages/macosx-amd64/list.json to obtain a revision
+      url = "file+https://github.com/argotorg/solc-bin/raw/26fc3fd/macosx-amd64/list.json";
       flake = false;
     };
   };

--- a/mk-solc-static-pkg.nix
+++ b/mk-solc-static-pkg.nix
@@ -14,7 +14,7 @@ let
   version = solc_ver;
   meta = with lib; {
     description = "Static binary of compiler for Ethereum smart contract language Solidity";
-    homepage = "https://github.com/ethereum/solidity";
+    homepage = "https://github.com/argotorg/solidity";
     license = licenses.gpl3;
     maintainers = with maintainers; [ hellwolf ];
     mainProgram = "solc-${solc_ver}";
@@ -39,7 +39,7 @@ let
 
   url =
     if solc-flavor == "solc-static-linux" then
-      "https://github.com/ethereum/solidity/releases/download/v${version}/solc-static-linux"
+      "https://github.com/argotorg/solidity/releases/download/v${version}/solc-static-linux"
     else if solc-flavor == "solc-macos-amd64" then
       macosUniversalBuildUrl
     else if solc-flavor == "solc-macos-aarch64" && builtins.compareVersions solc_ver "0.8.5" > -1 then

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -52,26 +52,25 @@
         "solc-macos-amd64-list-json": "solc-macos-amd64-list-json"
       },
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-OEV5w35uW7DEMdKAl9PteeKTQInS6mT6A+SUOwi4Dls=",
         "path": "../.",
         "type": "path"
       },
       "original": {
         "path": "../.",
         "type": "path"
-      }
+      },
+      "parent": []
     },
     "solc-macos-amd64-list-json": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-Prwz95BgMHcWd72VwVbcH17LsV9f24K2QMcUiWUQZzI=",
+        "narHash": "sha256-AvITkfpNYgCypXuLJyqco0li+unVw39BAfdOZvd/SPE=",
         "type": "file",
-        "url": "https://github.com/ethereum/solc-bin/raw/f743ca7/macosx-amd64/list.json"
+        "url": "https://github.com/argotorg/solc-bin/raw/26fc3fd/macosx-amd64/list.json"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/ethereum/solc-bin/raw/f743ca7/macosx-amd64/list.json"
+        "url": "https://github.com/argotorg/solc-bin/raw/26fc3fd/macosx-amd64/list.json"
       }
     },
     "systems": {

--- a/utils/download.sh
+++ b/utils/download.sh
@@ -29,7 +29,7 @@ download_one_version() {
 
     mkdir -p "$T/bin/static-linux"
     run_wget \
-        https://github.com/ethereum/solidity/releases/download/v"$v"/solc-static-linux \
+        https://github.com/argotorg/solidity/releases/download/v"$v"/solc-static-linux \
         "$T"/bin/static-linux/solc-"$v"
 
     mkdir -p "$T/bin/macos-amd64"
@@ -41,7 +41,7 @@ download_one_version() {
     if [ "$(semver compare $v 0.8.23)" == 1 ]; then
         # starting from 0.8.24, official solidity distribution started to provide universal builds
         # references:
-        # - https://github.com/ethereum/solidity/issues/14813
+        # - https://github.com/argotorg/solidity/issues/14813
         # - https://github.com/alloy-rs/solc-builds/issues/13
         ln -s ../macos-amd64/solc-"$v" "$T"/bin/macos-aarch64/solc-"$v"
     else


### PR DESCRIPTION
These repositories were moved to `argotorg`